### PR TITLE
Added support for downloading examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Once you're up and running with Create React Native App, visit [this tutorial](h
 
 ### Templates
 
-By default you create a bare-workflow React project with support for iOS, Android, and web. You can opt to use an example project instead by selecting the "Examples from Expo" option. Custom templates can be used with `--template <Github URL>` option.
+By default you create a bare-workflow React project with support for iOS, Android, and web. You can opt to use an example project instead by selecting the "Templates from ..." option. Custom templates can be used with `--template <Github URL>` option.
 
 - Use a custom template: `npx create-react-native-app --template https://github.com/someone/my-expo-starter` -- Only works with Github repos on the master branch.
 - All examples can be modified in the [expo/examples](https://github.com/expo/examples) repo.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once you're up and running with Create React Native App, visit [this tutorial](h
 - Support for unimodules and auto-linking.
 - OTA updates, and Gestures out of the box.
 - Full support for React Native web.
-- TypeScript by default.
+- Plug-n-play custom templates.
 - Works with the Expo Client app.
 
 ## Usage
@@ -41,6 +41,13 @@ Once you're up and running with Create React Native App, visit [this tutorial](h
 - `yarn ios` -- (`react-native run-ios`) Build the iOS App (requires a MacOS computer).
 - `yarn android` -- (`react-native run-android`) Build the Android App.
 - `yarn web` -- (`expo start:web`) Run the website in your browser.
+
+### Templates
+
+By default you create a bare-workflow React project with support for iOS, Android, and web. You can opt to use an example project instead by selecting the "Examples from Expo" option. Custom templates can be used with `--template <Github URL>` option.
+
+- Use a custom template: `npx create-react-native-app --template https://github.com/someone/my-expo-starter` -- Only works with Github repos on the master branch.
+- All examples can be modified in the [expo/examples](https://github.com/expo/examples) repo.
 
 ## Sections
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "Evan Bacon <bacon@expo.io> (https://github.com/evanbacon)"
   ],
   "files": [
-    "build"
+    "build",
+    "template"
   ],
   "bin": {
     "create-react-native-app": "./build/index.js"
@@ -57,21 +58,22 @@
     "@zeit/ncc": "^0.20.4",
     "chalk": "2.4.2",
     "commander": "2.20.0",
+    "eslint": "^6.6.0",
+    "eslint-config-universe": "^2.1.0",
     "fs-extra": "^9.0.0",
     "getenv": "^1.0.0",
+    "husky": "^1.1.3",
     "js-yaml": "^3.13.1",
+    "lint-staged": "^8.0.4",
     "minipass": "^3.1.1",
     "ora": "^4.0.3",
     "pacote": "^11.1.4",
+    "prettier": "^1.19.0",
     "prompts": "2.1.0",
     "tar": "^6.0.1",
     "terminal-link": "^2.1.1",
     "typescript": "3.7.3",
     "update-check": "1.5.4",
-    "eslint": "^6.6.0",
-    "eslint-config-universe": "^2.1.0",
-    "husky": "^1.1.3",
-    "lint-staged": "^8.0.4",
-    "prettier": "^1.19.0"
+    "got": "^11.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-config-universe": "^2.1.0",
     "fs-extra": "^9.0.0",
     "getenv": "^1.0.0",
+    "got": "^11.1.3",
     "husky": "^1.1.3",
     "js-yaml": "^3.13.1",
     "lint-staged": "^8.0.4",
@@ -73,7 +74,6 @@
     "tar": "^6.0.1",
     "terminal-link": "^2.1.1",
     "typescript": "3.7.3",
-    "update-check": "1.5.4",
-    "got": "^11.1.3"
+    "update-check": "1.5.4"
   }
 }

--- a/src/Examples.ts
+++ b/src/Examples.ts
@@ -1,0 +1,249 @@
+/**
+ * Inspired by create-next-app
+ */
+import chalk from 'chalk';
+import fs from 'fs';
+import got from 'got';
+import path from 'path';
+import prompts from 'prompts';
+import { Stream } from 'stream';
+import tar from 'tar';
+import { promisify } from 'util';
+
+// @ts-ignore
+const pipeline = promisify(Stream.pipeline);
+
+type RepoInfo = {
+  username: string;
+  name: string;
+  branch: string;
+  filePath: string;
+};
+
+export async function promptAsync(): Promise<string | null> {
+  const { value } = await prompts({
+    type: 'select',
+    name: 'value',
+    message: 'How would you like to start',
+    choices: [
+      { title: 'Default new app', value: 'default' },
+      { title: 'Examples from Expo', value: 'example' },
+    ],
+  });
+
+  if (!value) {
+    console.log();
+    console.log('Please specify the template');
+    process.exit(1);
+  }
+
+  if (value === 'example') {
+    let examplesJSON: any;
+
+    try {
+      examplesJSON = await listAsync();
+    } catch (error) {
+      console.log();
+      console.log('Failed to fetch the list of examples with the following error:');
+      console.error(error);
+      console.log();
+      console.log('Switching to the default starter app');
+      console.log();
+    }
+
+    if (examplesJSON) {
+      const choices = examplesJSON.map(({ name }: any) => ({
+        title: name,
+        value: name,
+      }));
+      // The search function built into `prompts` isn’t very helpful:
+      // someone searching for `styled-components` would get no results since
+      // the example is called `with-styled-components`, and `prompts` searches
+      // the beginnings of titles.
+      const nameRes = await prompts({
+        type: 'autocomplete',
+        name: 'exampleName',
+        message: 'Pick an example',
+        choices,
+        suggest: (input: any, choices: any) => {
+          const regex = new RegExp(input, 'i');
+          return choices.filter((choice: any) => regex.test(choice.title));
+        },
+      });
+
+      if (!nameRes.exampleName) {
+        console.log();
+        console.log('Please specify an example or use the default starter app.');
+        process.exit(1);
+      }
+
+      return nameRes.exampleName.trim();
+    }
+  }
+
+  return null;
+}
+
+async function isUrlOk(url: string): Promise<boolean> {
+  const res = await got(url).catch(e => e);
+  return res.statusCode === 200;
+}
+
+export async function getRepoInfo(url: any, examplePath?: string): Promise<RepoInfo | undefined> {
+  const [, username, name, t, _branch, ...file] = url.pathname.split('/');
+  const filePath = examplePath ? examplePath.replace(/^\//, '') : file.join('/');
+
+  // Support repos whose entire purpose is to be an example, e.g.
+  // https://github.com/:username/:my-cool-example-repo-name.
+  if (t === undefined) {
+    const infoResponse = await got(`https://api.github.com/repos/${username}/${name}`).catch(
+      e => e
+    );
+    if (infoResponse.statusCode !== 200) {
+      return;
+    }
+    const info = JSON.parse(infoResponse.body);
+    return { username, name, branch: info['default_branch'], filePath };
+  }
+
+  // If examplePath is available, the branch name takes the entire path
+  const branch = examplePath
+    ? `${_branch}/${file.join('/')}`.replace(new RegExp(`/${filePath}|/$`), '')
+    : _branch;
+
+  if (username && name && branch && t === 'tree') {
+    return { username, name, branch, filePath };
+  }
+  return undefined;
+}
+
+export function hasRepo({ username, name, branch, filePath }: RepoInfo) {
+  const contentsUrl = `https://api.github.com/repos/${username}/${name}/contents`;
+  const packagePath = `${filePath ? `/${filePath}` : ''}/package.json`;
+
+  return isUrlOk(contentsUrl + packagePath + `?ref=${branch}`);
+}
+
+export async function resolveTemplateArgAsync(
+  projectRoot: string,
+  oraInstance: any,
+  template: string,
+  templatePath?: string
+) {
+  let repoInfo: RepoInfo | undefined;
+
+  if (template) {
+    // @ts-ignore
+    let repoUrl: URL | undefined;
+
+    try {
+      // @ts-ignore
+      repoUrl = new URL(template);
+    } catch (error) {
+      if (error.code !== 'ERR_INVALID_URL') {
+        oraInstance.error(error);
+        process.exit(1);
+      }
+    }
+
+    if (repoUrl) {
+      if (repoUrl.origin !== 'https://github.com') {
+        oraInstance.error(
+          `Invalid URL: ${chalk.red(
+            `"${template}"`
+          )}. Only GitHub repositories are supported. Please use a GitHub URL and try again.`
+        );
+        process.exit(1);
+      }
+
+      repoInfo = await getRepoInfo(repoUrl, templatePath);
+
+      if (!repoInfo) {
+        oraInstance.error(
+          `Found invalid GitHub URL: ${chalk.red(
+            `"${template}"`
+          )}. Please fix the URL and try again.`
+        );
+        process.exit(1);
+      }
+
+      const found = await hasRepo(repoInfo);
+
+      if (!found) {
+        oraInstance.error(
+          `Could not locate the repository for ${chalk.red(
+            `"${template}"`
+          )}. Please check that the repository exists and try again.`
+        );
+        process.exit(1);
+      }
+    } else {
+      const found = await hasExample(template);
+
+      if (!found) {
+        oraInstance.error(
+          `Could not locate an example named ${chalk.red(
+            `"${template}"`
+          )}. Please check your spelling and try again.`
+        );
+        process.exit(1);
+      }
+    }
+  }
+
+  if (repoInfo) {
+    oraInstance.text = chalk.bold(
+      `Downloading files from repo ${chalk.cyan(template)}. This might take a moment.`
+    );
+
+    await downloadAndExtractRepo(projectRoot, repoInfo);
+  } else {
+    oraInstance.text = chalk.bold(
+      `Downloading files for example ${chalk.cyan(template)}. This might take a moment.`
+    );
+
+    await downloadAndExtractExample(projectRoot, template);
+  }
+
+  await ensureProjectHasGitIgnore(projectRoot);
+
+  return true;
+}
+
+function ensureProjectHasGitIgnore(projectRoot: string): void {
+  // Copy our default `.gitignore` if the application did not provide one
+  const ignorePath = path.join(projectRoot, '.gitignore');
+  if (!fs.existsSync(ignorePath)) {
+    fs.copyFileSync(require.resolve('../template/gitignore'), ignorePath);
+  }
+}
+
+function hasExample(name: string): Promise<boolean> {
+  return isUrlOk(
+    `https://api.github.com/repos/expo/examples/contents/${encodeURIComponent(name)}/package.json`
+  );
+}
+
+function downloadAndExtractRepo(
+  root: string,
+  { username, name, branch, filePath }: RepoInfo
+): Promise<void> {
+  const strip = filePath ? filePath.split('/').length + 1 : 1;
+  return pipeline(
+    got.stream(`https://codeload.github.com/${username}/${name}/tar.gz/${branch}`),
+    tar.extract({ cwd: root, strip }, [`${name}-${branch}${filePath ? `/${filePath}` : ''}`])
+  );
+}
+
+function downloadAndExtractExample(root: string, name: string): Promise<void> {
+  return pipeline(
+    got.stream('https://codeload.github.com/expo/examples/tar.gz/master'),
+    tar.extract({ cwd: root, strip: 2 }, [`examples-master/${name}`])
+  );
+}
+
+async function listAsync(): Promise<any> {
+  const res = await got('https://api.github.com/repos/expo/examples/contents');
+  const results = JSON.parse(res.body);
+  return results.filter(({ name, type }: any) => type === 'dir' && !name?.startsWith('.'));
+}

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -66,7 +66,7 @@ function createFileTransform(config: AppJSONConfig) {
 
 // Currently only support bare JS project
 // TODO(Bacon): Add examples
-const templateSpec = npmPackageArg('expo-template-bare-typescript');
+const templateSpec = npmPackageArg('expo-template-blank');
 
 /**
  * Extract a template app to a given file path and clean up any properties left over from npm to

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { ensureDir } from 'fs-extra';
+import { ensureDir, existsSync } from 'fs-extra';
 import * as path from 'path';
 import prompts from 'prompts';
 
+import * as Examples from './Examples';
 import log from './Logger';
 import * as Template from './Template';
 import shouldUpdate, { shouldUseYarn } from './Update';
@@ -20,19 +20,33 @@ const program = new Command(packageJSON.name)
   .usage(`${chalk.magenta('<project-root>')} [options]`)
   .description('Creates a new React Native project')
   .option('--use-npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
+  .option('--template [url]', 'The URL to a github repo that contains an example.')
+  .option('--template-path [name]', 'The path inside of a github repo where the example lives.')
   .allowUnknownOption()
   .action(projectRoot => (inputPath = projectRoot))
   .parse(process.argv);
 
 async function runAsync(): Promise<void> {
-  // Command Entry Point
   try {
     const projectRoot = await resolveProjectRootAsync(inputPath);
 
-    let extractTemplateStep = Template.logNewSection('Downloading and extracting project files.');
-    let projectPath;
+    let resolvedTemplate = program.template ?? (await Examples.promptAsync());
+    let templatePath = program.templatePath;
+
+    await ensureDir(projectRoot);
+    let extractTemplateStep = Template.logNewSection(`Downloading and extracting project files.`);
+
     try {
-      projectPath = await Template.extractAndPrepareTemplateAppAsync(projectRoot);
+      if (resolvedTemplate) {
+        await Examples.resolveTemplateArgAsync(
+          projectRoot,
+          extractTemplateStep,
+          resolvedTemplate,
+          templatePath
+        );
+      } else {
+        await Template.extractAndPrepareTemplateAppAsync(projectRoot);
+      }
       extractTemplateStep.succeed('Downloaded and extracted project files.');
     } catch (e) {
       extractTemplateStep.fail(
@@ -41,6 +55,8 @@ async function runAsync(): Promise<void> {
       process.exit(1);
     }
 
+    await maybeInstallDependenciesAsync(projectRoot);
+
     // for now, we will just init a git repo if they have git installed and the
     // project is not inside an existing git tree, and do it silently. we should
     // at some point check if git is installed and actually bail out if not, because
@@ -48,12 +64,10 @@ async function runAsync(): Promise<void> {
     try {
       // check if git is installed
       // check if inside git repo
-      await Template.initGitRepoAsync(projectPath, { silent: true });
+      await Template.initGitRepoAsync(projectRoot, { silent: true });
     } catch {
       // todo: check if git is installed, bail out
     }
-
-    await maybeInstallDependenciesAsync(projectPath);
   } catch (error) {
     await commandDidThrowAsync(error);
   }
@@ -78,21 +92,25 @@ async function maybeInstallDependenciesAsync(projectPath: string): Promise<void>
     cdPath = projectPath;
   }
 
+  const needsPodInstall = await existsSync(path.join(projectPath, 'ios'));
+
   let podsInstalled = false;
-  try {
-    podsInstalled = await Template.installPodsAsync(projectPath);
-  } catch (_) {}
+  if (needsPodInstall) {
+    try {
+      podsInstalled = await Template.installPodsAsync(projectPath);
+    } catch (_) {}
+  }
 
   log.newLine();
   Template.logProjectReady({ cdPath, packageManager });
-  if (!podsInstalled && process.platform === 'darwin') {
+  if (needsPodInstall && !podsInstalled && process.platform === 'darwin') {
     log.newLine();
     log.nested(
       `⚠️  Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:`
     );
     log.nested('');
     log.nested(`  cd ${cdPath ?? '.'}/ios`);
-    log.nested(`  pod install`);
+    log.nested(`  npx pod-install`);
     log.nested('');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ async function runAsync(): Promise<void> {
           resolvedTemplate,
           templatePath
         );
+
+        await Examples.appendScriptsAsync(projectRoot);
       } else {
         await Template.extractAndPrepareTemplateAppAsync(projectRoot);
       }

--- a/template/gitignore
+++ b/template/gitignore
@@ -1,0 +1,63 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+*/fastlane/report.xml
+*/fastlane/Preview.html
+*/fastlane/screenshots
+
+# Bundle artifacts
+*.jsbundle
+
+# CocoaPods
+/ios/Pods/
+
+# Expo
+.expo/*
+web-build/

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,10 +887,32 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sindresorhus/is@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.1.tgz#ceff6a28a5b4867c2dd4a1ba513de278ccbe8bb1"
+  integrity sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
+  integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
 "@tootallnate/once@1":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
   integrity sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==
+
+"@types/cacheable-request@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -916,6 +938,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/http-cache-semantics@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
 "@types/js-yaml@^3.12.3":
   version "3.12.3"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.3.tgz#abf383c5b639d0aa8b8c4a420d6a85f703357d6c"
@@ -925,6 +952,13 @@
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
+"@types/keyv@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/minipass@*":
   version "2.2.0"
@@ -952,6 +986,13 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.1.tgz#afae5a8b0616a33cd31557bec74e2fd4a32f4afe"
   integrity sha512-AhtMcmETelF8wFDV1ucbChKhLgsc+ytXZXkNz/nnTAMSDeqsjALknEFxi7ZtLgS/G8bV2rp90LhDW5SGACimIQ==
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/tar@4.0.3":
   version "4.0.3"
@@ -1315,6 +1356,24 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-lookup@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-4.3.0.tgz#86ff1cb38f648cc6aba28feffe008f808b403550"
+  integrity sha512-PTUoCeIjj2awloqyVRUL33SjquU1Qv5xuDalYY8WAzd9NnUMUivZnGsOzVsMfg2YuMsWXaXkd/hjnsVoWc/3YA==
+
+cacheable-request@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
+  integrity sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^2.0.0"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -1439,6 +1498,13 @@ cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
+
+clone-response@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -1601,6 +1667,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-5.0.0.tgz#7849396e80e3d1eba8cb2f75ef4930f76461cb0f"
+  integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -1621,6 +1694,11 @@ defaults@^1.0.3:
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
+  integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -2270,6 +2348,13 @@ get-stream@^4.0.0:
   dependencies:
     pump "^3.0.0"
 
+get-stream@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -2332,6 +2417,24 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+got@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.1.3.tgz#bcb624c636f9c4da5a82a7d7c9017fcad6e2905a"
+  integrity sha512-JnGxEHZiy0ZArb/zhfu1Gxoksy9PjhQ4GAk6N4UArV/m1JdE7cGNVXbUDnrQk+nU7UPMDX+BHQAP0daMjsnTtQ==
+  dependencies:
+    "@sindresorhus/is" "^2.1.1"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^4.3.0"
+    cacheable-request "^7.0.1"
+    decompress-response "^5.0.0"
+    get-stream "^5.1.0"
+    http2-wrapper "^1.0.0-beta.4.5"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
@@ -2416,7 +2519,7 @@ hosted-git-info@^3.0.2:
   dependencies:
     lru-cache "^5.1.1"
 
-http-cache-semantics@^4.0.4:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.0.4:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -2429,6 +2532,14 @@ http-proxy-agent@^4.0.1:
     "@tootallnate/once" "1"
     agent-base "6"
     debug "4"
+
+http2-wrapper@^1.0.0-beta.4.5:
+  version "1.0.0-beta.4.6"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.0-beta.4.6.tgz#9438f0fceb946c8cbd365076c228a4d3bd4d0143"
+  integrity sha512-9oB4BiGDTI1FmIBlOF9OJ5hwJvcBEmPCqk/hy314Uhy2uq5TjekUZM8w8SPLLlUEM+mxNhXdPAXfrJN2Zbb/GQ==
+  dependencies:
+    quick-lru "^5.0.0"
+    resolve-alpn "^1.0.0"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -2842,6 +2953,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -2904,6 +3020,13 @@ jsx-ast-utils@^2.2.3:
   dependencies:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
+
+keyv@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.1.tgz#9fe703cb4a94d6d11729d320af033307efd02ee6"
+  integrity sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==
+  dependencies:
+    json-buffer "3.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3098,6 +3221,11 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -3172,6 +3300,16 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -3339,6 +3477,11 @@ normalize-package-data@^2.3.2:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-url@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
 npm-bundled@^1.1.1:
   version "1.1.1"
@@ -3585,6 +3728,11 @@ osenv@^0.1.5:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-cancelable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
+  integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -3849,6 +3997,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+quick-lru@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.0.tgz#1602f339bde554c4dace47880227ec9c2869f2e8"
+  integrity sha512-WjAKQ9ORzvqjLijJXiXWqc3Gcs1ivoxCj6KJmEjoWBE6OtHwuaDLSAUqGHALUiid7A1KqGqsSHZs8prxF5xxAQ==
+
 rc@^1.0.1, rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -4018,6 +4171,11 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+resolve-alpn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
+  integrity sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -4039,6 +4197,13 @@ resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2:
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
+
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Select a native example from `expo/examples` as a starting point for your app
- Use npx pod-install
- Only pod install if an ios folder exists
- Use JS template by default now that TS is available via expo examples. fix #798
- Append scripts to template projects based on the workflow
- Move git init to after the install. fix #797