### PR TITLE
Upgrade ncc

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^12.6.8",
     "@types/prompts": "2.0.1",
     "@types/tar": "4.0.3",
-    "@zeit/ncc": "^0.20.4",
+    "@zeit/ncc": "^0.22.3",
     "babel-jest": "^26.0.1",
     "chalk": "2.4.2",
     "commander": "2.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,10 +1311,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@zeit/ncc@^0.20.4":
-  version "0.20.5"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.5.tgz#a41af6e6bcab4a58f4612bae6137f70bce0192e3"
-  integrity sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==
+"@zeit/ncc@^0.22.3":
+  version "0.22.3"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.22.3.tgz#fca6b86b4454ce7a7e1e7e755165ec06457f16cd"
+  integrity sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==
 
 abab@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
Upgraded `ncc` to v0.22.3. This fixes source map generation, which makes it possible to inspect the contents of the bundle like this:
```
yarn build --source-map
npx source-map-explorer build/index.js
```

<img width="2478" alt="Screen Shot 2020-05-25 at 10 39 20" src="https://user-images.githubusercontent.com/497214/82790395-a7648880-9e74-11ea-8b00-c4b7b75e1a38.png">

BTW, @EvanBacon you've done a great job making this package lightweight – I'm truly inspired by it.
