### PR TITLE
Remove template folder from the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "Evan Bacon <bacon@expo.io> (https://github.com/evanbacon)"
   ],
   "files": [
-    "build",
-    "template"
+    "build"
   ],
   "bin": {
     "create-react-native-app": "./build/index.js"


### PR DESCRIPTION
NCC copies the [`template/gitigore` file to the `build` folder](https://unpkg.com/browse/create-react-native-app@3.4.0/build/gitignore) anyway, so right now it was being included twice.