### PR TITLE
Add .hprof files to template/gitignore

### DIFF
--- a/template/gitignore
+++ b/template/gitignore
@@ -29,6 +29,7 @@ build/
 .gradle
 local.properties
 *.iml
+*.hprof
 
 # node.js
 #


### PR DESCRIPTION
.hprof files are created as a heap dump of the memory of a Java process. They are usually created when something goes wrong during an Android run or build (For example an out of memory error). As these are dump files, they are pretty big and shouldn't be committed.