### PR TITLE
Remove `expo eject` command from template generation

### DIFF
--- a/src/Examples.ts
+++ b/src/Examples.ts
@@ -236,7 +236,7 @@ function getScriptsForProject(projectRoot: string): Record<string, string> {
     start: 'expo start',
     android: 'expo start --android',
     ios: 'expo start --ios',
-    web: 'expo start --web'
+    web: 'expo start --web',
   };
 }
 

--- a/src/Examples.ts
+++ b/src/Examples.ts
@@ -236,8 +236,7 @@ function getScriptsForProject(projectRoot: string): Record<string, string> {
     start: 'expo start',
     android: 'expo start --android',
     ios: 'expo start --ios',
-    web: 'expo start --web',
-    eject: 'expo eject',
+    web: 'expo start --web'
   };
 }
 


### PR DESCRIPTION
`expo eject` has been deprecated and will be removed in the next CLI release. Generated templates should no longer have `expo eject` as part of the NPM scripts.