### PR TITLE
fix: typo from 'when' to 'went'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ async function installNodeDependenciesAsync(
     installJsDepsStep.succeed('Installed JavaScript dependencies.');
   } catch {
     installJsDepsStep.fail(
-      `Something when wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to initialize the app.`
+      `Something went wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to initialize the app.`
     );
   }
 }


### PR DESCRIPTION
fixed typo in src/index.ts

```diff
- Something when wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to initialize the app.
+ Something went wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to initialize the app.
```
closes issue: #901 
