### PR TITLE
fix: prevent processing font files

### DIFF
--- a/src/createFileTransform.ts
+++ b/src/createFileTransform.ts
@@ -64,6 +64,10 @@ export function createFileTransform(name: string) {
         '.svg',
         '.jar',
         '.keystore',
+
+        // Font files
+        '.otf',
+        '.ttf',
       ].includes(path.extname(entry.path)) &&
       name
     ) {


### PR DESCRIPTION
- Same as https://github.com/expo/expo/pull/17184
- Prevent parsing fonts when cloning examples