### PR TITLE
fix: skip creating a git repo when inside existing repo

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -159,10 +159,10 @@ describe('yes', () => {
     expect(fileExists(workspaceName, '.git')).toBe(true);
     expect(fileExists(projectRoot, '.git')).not.toBe(true);
 
-    expect(fileExists(workspaceName, 'package.json')).toBe(true);
-    expect(fileExists(workspaceName, 'App.js')).toBe(true);
-    expect(fileExists(workspaceName, '.gitignore')).toBe(true);
-    expect(fileExists(workspaceName, 'node_modules')).toBe(true);
+    expect(fileExists(projectRoot, 'package.json')).toBe(true);
+    expect(fileExists(projectRoot, 'App.js')).toBe(true);
+    expect(fileExists(projectRoot, '.gitignore')).toBe(true);
+    expect(fileExists(projectRoot, 'node_modules')).toBe(true);
   });
 });
 

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -156,13 +156,13 @@ describe('yes', () => {
     const results = await execa('node', [cli, '--yes'], { cwd: projectRoot });
     expect(results.exitCode).toBe(0);
 
-    expect(fileExists(workspaceName, '.git')).toBe(true);
-    expect(fileExists(projectRoot, '.git')).not.toBe(true);
+    expect(existsSync(path.join(workspaceRoot, '.git'))).toBe(true);
+    expect(existsSync(path.join(projectRoot, '.git'))).not.toBe(true);
 
-    expect(fileExists(projectRoot, 'package.json')).toBe(true);
-    expect(fileExists(projectRoot, 'App.js')).toBe(true);
-    expect(fileExists(projectRoot, '.gitignore')).toBe(true);
-    expect(fileExists(projectRoot, 'node_modules')).toBe(true);
+    expect(existsSync(path.join(projectRoot, 'package.json'))).toBe(true);
+    expect(existsSync(path.join(projectRoot, 'App.js'))).toBe(true);
+    expect(existsSync(path.join(projectRoot, '.gitignore'))).toBe(true);
+    expect(existsSync(path.join(projectRoot, 'node_modules'))).toBe(true);
   });
 });
 

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -141,6 +141,29 @@ describe('yes', () => {
     expect(fileExists(projectName, '.gitignore')).toBeTruthy();
     expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
   });
+  it('does not create a new git repository inside an existing repository', async () => {
+    const workspaceName = 'yes-skip-git-in-repo';
+    const workspaceRoot = getRoot(workspaceName);
+
+    // Create the workspace root, and basic monorepo structure
+    await fs.mkdirp(workspaceRoot);
+    await execa('git', ['init'], { cwd: workspaceRoot });
+
+    // Create the app within a basic monorepo structure
+    const projectRoot = path.join(workspaceRoot, 'apps', workspaceName);
+    await fs.mkdirp(projectRoot);
+
+    const results = await execa('node', [cli, '--yes'], { cwd: projectRoot });
+    expect(results.exitCode).toBe(0);
+
+    expect(fileExists(workspaceName, '.git')).toBe(true);
+    expect(fileExists(projectRoot, '.git')).not.toBe(true);
+
+    expect(fileExists(workspaceName, 'package.json')).toBe(true);
+    expect(fileExists(workspaceName, 'App.js')).toBe(true);
+    expect(fileExists(workspaceName, '.gitignore')).toBe(true);
+    expect(fileExists(workspaceName, 'node_modules')).toBe(true);
+  });
 });
 
 describe('templates', () => {

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -110,6 +110,7 @@ export async function initGitRepoAsync(
   try {
     await spawnAsync('git', ['rev-parse', '--is-inside-work-tree'], { stdio: 'ignore', cwd: root });
     !flags.silent && Logger.gray('New project is already inside of a Git repo, skipping git init.');
+    return false;
   } catch (e) {
     if (e.errno === 'ENOENT') {
       !flags.silent && Logger.gray('Unable to initialize Git repo. `git` not in PATH.');


### PR DESCRIPTION
Part of ENG-7078

When creating a new app inside a monorepo, we should not create a new git repository.