### PR TITLE
fix: convert underscore files to dotfiles (a la RN CLI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^12.6.8",
     "@types/prompts": "2.0.8",
     "@types/tar": "4.0.3",
-    "@vercel/ncc": "^0.27.0",
+    "@vercel/ncc": "^0.36.1",
     "babel-jest": "^26.0.1",
     "chalk": "2.4.2",
     "commander": "2.20.0",

--- a/src/Examples.ts
+++ b/src/Examples.ts
@@ -151,7 +151,7 @@ export async function resolveTemplateArgAsync(
       // @ts-ignore
       repoUrl = new URL(template);
     } catch (error) {
-      // @ts-ignore
+      // @ts-expect-error
       if (error.code !== 'ERR_INVALID_URL') {
         oraInstance.fail(error);
         process.exit(1);

--- a/src/Examples.ts
+++ b/src/Examples.ts
@@ -151,6 +151,7 @@ export async function resolveTemplateArgAsync(
       // @ts-ignore
       repoUrl = new URL(template);
     } catch (error) {
+      // @ts-ignore
       if (error.code !== 'ERR_INVALID_URL') {
         oraInstance.fail(error);
         process.exit(1);

--- a/src/createFileTransform.ts
+++ b/src/createFileTransform.ts
@@ -30,6 +30,23 @@ class Transformer extends Minipass {
   }
 }
 
+// Files and directories that have `_` as their first character in React Native CLI templates
+// These should be transformed to have `.` as the first character
+const UNDERSCORED_DOTFILES = [
+  'buckconfig',
+  'eslintrc.js',
+  'flowconfig',
+  'gitattributes',
+  'gitignore',
+  'prettierrc.js',
+  'watchmanconfig',
+  'editorconfig',
+  'bundle',
+  'ruby-version',
+  'node-version',
+  'xcode.env',
+];
+
 export function createEntryResolver(name: string) {
   return (entry: ReadEntry) => {
     if (name) {
@@ -45,6 +62,9 @@ export function createEntryResolver(name: string) {
       // Rename `gitignore` because npm ignores files named `.gitignore` when publishing.
       // See: https://github.com/npm/npm/issues/1862
       entry.path = entry.path.replace(/gitignore$/, '.gitignore');
+    }
+    for (const fileName of UNDERSCORED_DOTFILES) {
+      entry.path = entry.path.replace(`_${fileName}`, `.${fileName}`);
     }
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,10 +1310,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vercel/ncc@^0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.27.0.tgz#c0cfeebb0bebb56052719efa4a0ecc090a932c76"
-  integrity sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==
+"@vercel/ncc@^0.36.1":
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.36.1.tgz#d4c01fdbbe909d128d1bf11c7f8b5431654c5b95"
+  integrity sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==
 
 abab@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
- Add the ability to convert the underscore-prepended files and directories in templates used by React Native CLI
- Fix a TS error
- Update a Vercel dependency (the previous version led to an error in `yarn build`)